### PR TITLE
esm import paths using tsc-esm-fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "esm": "^3.2.25",
         "nodemon": "^3.1.9",
         "ts-node": "^10.9.2",
+        "tsc-alias": "^1.8.16",
+        "tsc-esm-fix": "^3.1.2",
         "typescript": "^5.7.3"
       }
     },
@@ -548,6 +550,44 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@redis/bloom": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-1.2.0.tgz",
@@ -606,6 +646,16 @@
       "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
       "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
       "hasInstallScript": true
+    },
+    "node_modules/@topoconfig/extends": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@topoconfig/extends/-/extends-0.16.2.tgz",
+      "integrity": "sha512-sTF+qpWakr5jf1Hn/kkFSi833xPW15s/loMAiKSYSSVv4vDonxf6hwCGzMXjLq+7HZoaK6BgaV72wXr1eY7FcQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "xtends": "target/esm/cli.mjs"
+      }
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -988,6 +1038,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1252,6 +1312,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/depseek": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/depseek/-/depseek-0.4.2.tgz",
+      "integrity": "sha512-nozwrTBO1VsNI9RvqPHo7pDAeYRfoLhjFjwiUcg+11VjOm7NJnmmAIa3l4Hy34fNw7Wq2iNdIl8Q1Q7EUCKZgQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/destroy": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
@@ -1276,6 +1343,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/doctrine": {
@@ -1486,6 +1566,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1529,6 +1636,21 @@
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs-minipass": {
@@ -1643,6 +1765,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1675,6 +1810,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1685,6 +1841,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -1779,6 +1942,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/ignore-by-default": {
@@ -1877,6 +2050,32 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -2046,12 +2245,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -2312,6 +2535,20 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/mylas": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.13.tgz",
+      "integrity": "sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -2502,6 +2739,16 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/pg": {
       "version": "8.13.1",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.1.tgz",
@@ -2668,6 +2915,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
@@ -2753,6 +3013,37 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -2813,10 +3104,31 @@
         "@redis/time-series": "1.1.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/retry-as-promised": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/retry-as-promised/-/retry-as-promised-7.0.4.tgz",
       "integrity": "sha512-XgmCoxKWkDofwH8WddD0w85ZfqYz+ZHlr5yo+3YUCfycWawU56T5ckWXsScsj5B8tqUcIG67DxXByo3VUgiAdA=="
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
@@ -2831,6 +3143,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -3108,6 +3444,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -3346,6 +3692,69 @@
         }
       }
     },
+    "node_modules/tsc-alias": {
+      "version": "1.8.16",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.16.tgz",
+      "integrity": "sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/tsc-esm-fix": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tsc-esm-fix/-/tsc-esm-fix-3.1.2.tgz",
+      "integrity": "sha512-1/OpZssMcEp2ae6DyZV+yvDviofuCdDf7dEWEaBvm/ac8vtS04lFyl0LVs8LQE56vjKHytgzVjPIL9udM4QuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@topoconfig/extends": "^0.16.2",
+        "depseek": "^0.4.1",
+        "fast-glob": "^3.3.2",
+        "fs-extra": "^11.2.0",
+        "json5": "^2.2.3",
+        "type-flag": "^3.0.0"
+      },
+      "bin": {
+        "tsc-esm-fix": "target/esm/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/type-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/type-flag/-/type-flag-3.0.0.tgz",
+      "integrity": "sha512-3YaYwMseXCAhBB14RXW5cRQfJQlEknS6i4C8fCfeUdS3ihG9EdccdR9kt3vP73ZdeTGmPb4bZtkDn5XMIn1DLA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/type-flag?sponsor=1"
+      }
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -3386,6 +3795,16 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2474,6 +2474,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "scripts": {
     "start": "tsc && node dist/App.js",
-    "build": "tsc",
-    "dev": "nodemon"
+    "build": "tsc && tsc-esm-fix ./dist",
+    "dev": "nodemon",
+    "seed": "node dist/seed/seeds.js"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -36,6 +37,8 @@
     "esm": "^3.2.25",
     "nodemon": "^3.1.9",
     "ts-node": "^10.9.2",
+    "tsc-alias": "^1.8.16",
+    "tsc-esm-fix": "^3.1.2",
     "typescript": "^5.7.3"
   }
 }

--- a/src/App.ts
+++ b/src/App.ts
@@ -19,13 +19,14 @@ app.use(cors({
 app.use(express.json());
 
 // const swaggerDocs = swaggerJsdoc(swaggerOptions);
-// app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
+// app.use("/api-docs", swagger Ui.serve, swaggerUi.setup(swaggerDocs));
 
 RouteHandler(app);
 
 app.get("/", (req, res) => {
   res.send({ message: "hello world!" });
 });
+
 
 const PORT = process.env.PORT || 5000;
 (async () => {

--- a/src/schema/v1/event.schema.ts
+++ b/src/schema/v1/event.schema.ts
@@ -34,4 +34,4 @@ const eventSchema = new Schema<IEvent>(
   { timestamps: true }
 );
 
-module.exports = mongoose.model<IEvent>('Event', eventSchema);
+ export default mongoose.model<IEvent>('Event', eventSchema);

--- a/src/schema/v1/event.schema.ts
+++ b/src/schema/v1/event.schema.ts
@@ -1,0 +1,37 @@
+import mongoose, { Schema } from "mongoose";
+import { IEvent } from "../../types/schema/v1/event.type";
+
+const eventSchema = new Schema<IEvent>(
+  {
+    eventName: {
+      type: String,
+      required: true,
+    },
+    eventDate: {
+      type: Date,
+      required: true,
+    },
+    eventSpeakers: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+      },
+    ],
+    venue: {
+      type: String,
+      required: true,
+    },
+    numberOfPeople: {
+      type: Number,
+      default: 0,
+    },
+    status: {
+      type: String,
+      enum: ['upcoming', 'completed'],
+      default: 'upcoming',
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model<IEvent>('Event', eventSchema);

--- a/src/schema/v1/package.schema.ts
+++ b/src/schema/v1/package.schema.ts
@@ -1,0 +1,13 @@
+import mongoose, { Schema } from "mongoose";
+import { IPackage } from "../../types/schema/v1/package.type";
+
+const packageSchema = new Schema<IPackage>(
+  {
+    packageName: String,
+    price: Number,
+    features: [String],
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model<IPackage>('Package', packageSchema);

--- a/src/schema/v1/package.schema.ts
+++ b/src/schema/v1/package.schema.ts
@@ -9,5 +9,4 @@ const packageSchema = new Schema<IPackage>(
   },
   { timestamps: true }
 );
-
-module.exports = mongoose.model<IPackage>('Package', packageSchema);
+ export default mongoose.model<IPackage>('Package', packageSchema);

--- a/src/schema/v1/school.schema.ts
+++ b/src/schema/v1/school.schema.ts
@@ -1,0 +1,35 @@
+import mongoose, { Schema } from "mongoose";
+import { ISchool } from "../../types/schema/v1/school..type";
+
+
+const schoolSchema = new Schema<ISchool>(
+  {
+    schoolName: {
+      type: String,
+      required: true,
+    },
+    schoolAddress: {
+      type: String,
+      required: true,
+    },
+    events: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Event',
+      },
+    ],
+    packages: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Package',
+      },
+    ],
+    principalName: {
+      type: String,
+      required: true,
+    },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model<ISchool>('School', schoolSchema);

--- a/src/schema/v1/school.schema.ts
+++ b/src/schema/v1/school.schema.ts
@@ -31,5 +31,4 @@ const schoolSchema = new Schema<ISchool>(
   },
   { timestamps: true }
 );
-
-module.exports = mongoose.model<ISchool>('School', schoolSchema);
+export default mongoose.model<ISchool>('School', schoolSchema);

--- a/src/schema/v1/user.schema.ts
+++ b/src/schema/v1/user.schema.ts
@@ -1,38 +1,19 @@
-/**
- * @swagger
- * components:
- *   schemas:
- *     CreateUser:
- *       type: object
- *       required:
- *         - email
- *         - phone
- *       properties:
- *         email:
- *           type: string
- *           example: user@example.com
- *         phone:
- *           type: string
- *           example: "9876543210"
- */
+import mongoose, { Schema } from 'mongoose';
+import { IUser } from '../../types/schema/v1/user.type';
 
-/**
- * @swagger
- * /create_user:
- *   post:
- *     summary: Create a new user
- *     description: API to create a new user
- *     tags: [User]
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             $ref: '#/components/schemas/CreateUser'
- *     responses:
- *       201:
- *         description: User created successfully
- *       400:
- *         description: Invalid input
- */
-export default {};
+const userSchema = new Schema<IUser>(
+  {
+    role: {
+      type: String,
+      enum: ['normal_user', 'admin', 'super_admin', 'speaker'],
+      default: 'normal_user',
+      required: true,
+    },
+    name: { type: String, required: true, trim: true },
+    email: { type: String, required: true, unique: true, lowercase: true },
+    password: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IUser>('User', userSchema);

--- a/src/seed/seeds.ts
+++ b/src/seed/seeds.ts
@@ -1,0 +1,107 @@
+import mongoose from 'mongoose';
+import User from '../schema/v1/user.schema';
+import Event from '../schema/v1/event.schema';
+import School from '../schema/v1/school.schema';
+import Package from '../schema/v1/package.schema';
+
+
+async function seed() {
+  try {
+    // ✅ DB connect
+    await mongoose.connect('mongodb://127.0.0.1:27017/mydatabase');
+    console.log('✅ MongoDB Connected for seeding');
+
+    // ✅ Clean old data (optional)
+    await User.deleteMany({});
+    await Event.deleteMany({});
+    await School.deleteMany({});
+    await Package.deleteMany({});
+    console.log('🧹 Old data cleared');
+
+    // ✅ Insert packageSchemas
+    const packageSchemas = await Package.insertMany([
+      {
+        packageSchemaName: 'Basic Plan',
+        price: 999,
+        features: ['2 events', 'Standard venue'],
+      },
+      {
+        packageSchemaName: 'Premium Plan',
+        price: 4999,
+        features: ['Unlimited events', 'VIP seating', 'Custom branding'],
+      },
+    ]);
+    console.log('📦 packageSchemas seeded');
+
+    // ✅ Insert Users
+    const users = await User.insertMany([
+      {
+        role: 'admin',
+        name: 'Deep',
+        email: 'deep@example.com',
+        password: 'hashedpassword',
+      },
+      {
+        role: 'speaker',
+        name: 'Rahul Sharma',
+        email: 'rahul@example.com',
+        password: 'hashedpassword',
+      },
+      {
+        role: 'normal_user',
+        name: 'Priya Singh',
+        email: 'priya@example.com',
+        password: 'hashedpassword',
+      },
+    ]);
+    console.log('👤 Users seeded');
+
+    // ✅ Insert Events
+    const events = await Event.insertMany([
+      {
+        eventName: 'Tech Conference 2025',
+        eventDate: new Date('2025-09-15'),
+        eventSpeakers: [users[1]._id],
+        venue: 'Delhi Convention Center',
+        numberOfPeople: 300,
+        status: 'upcoming',
+      },
+      {
+        eventName: 'AI Workshop',
+        eventDate: new Date('2025-07-10'),
+        eventSpeakers: [users[1]._id],
+        venue: 'Mumbai Tech Hub',
+        numberOfPeople: 150,
+        status: 'completed',
+      },
+    ]);
+    console.log('🎤 Events seeded');
+
+    // ✅ Insert Schools
+    await School.insertMany([
+      {
+        schoolName: 'Green Valley High School',
+        schoolAddress: '123, Park Street, Delhi',
+        events: [events[0]._id, events[1]._id],
+        packageSchemas: [packageSchemas[0]._id],
+        principalName: 'Mr. Arjun Verma',
+      },
+      {
+        schoolName: 'Sunrise Public School',
+        schoolAddress: '456, MG Road, Mumbai',
+        events: [events[0]._id],
+        packageSchemas: [packageSchemas[1]._id],
+        principalName: 'Mrs. Kavita Joshi',
+      },
+    ]);
+    console.log('🏫 Schools seeded');
+
+    console.log('🎉 Seeding complete!');
+    process.exit(); // ✅ Exit after seeding
+  } catch (err) {
+    console.error('❌ Seeding error:', err);
+    process.exit(1);
+  }
+}
+
+seed();

--- a/src/types/schema/v1/event.type.ts
+++ b/src/types/schema/v1/event.type.ts
@@ -1,0 +1,14 @@
+import { Document, Types } from 'mongoose';
+import { IUser } from './user.type';
+
+
+export type EventStatus = 'upcoming' | 'completed';
+
+export interface IEvent extends Document {
+  eventName: string;
+  eventDate: Date;
+  eventSpeakers: Types.ObjectId[] | IUser[];
+  venue: string;
+  numberOfPeople: number;
+  status: EventStatus;
+}

--- a/src/types/schema/v1/package.type.ts
+++ b/src/types/schema/v1/package.type.ts
@@ -1,0 +1,7 @@
+import { Document } from 'mongoose';
+
+export interface IPackage extends Document {
+  packageName: string;
+  price: number;
+  features: string[];
+}

--- a/src/types/schema/v1/school..type.ts
+++ b/src/types/schema/v1/school..type.ts
@@ -1,0 +1,11 @@
+import { Document, Types } from 'mongoose';
+import { IEvent } from './event.type';
+
+
+export interface ISchool extends Document {
+  schoolName: string;
+  schoolAddress: string;
+  events: Types.ObjectId[] | IEvent[];
+  packages: Types.ObjectId[];
+  principalName: string;
+}

--- a/src/types/schema/v1/user.type.ts
+++ b/src/types/schema/v1/user.type.ts
@@ -1,0 +1,10 @@
+import { Document } from 'mongoose';
+
+export type UserRole = 'normal_user' | 'admin' | 'super_admin' | 'speaker';
+
+export interface IUser extends Document {
+  role: UserRole;
+  name: string;
+  email: string;
+  password: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,17 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "ESNext", 
+    "module": "ESNext",
     "moduleResolution": "Node",
     "outDir": "./dist",
     "rootDir": "./src",
+    "baseUrl": "./",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "paths": {
+      "*": ["src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## 🚀 PR Description  

### 1️⃣ Problem Faced  
When running `npm run seed`, Node.js threw an error:  


- TypeScript compiled with `"module": "ESNext"` was generating ESM imports without file extensions.  
- Node.js (v22+) requires `.js` extensions in relative imports.  
- As a result, the compiled `dist/seed/seeds.js` couldn’t resolve schema files.  

---

### 2️⃣ Solution Implemented  
- Added the **`tsc-esm-fix`** package to automatically append `.js` extensions to all relative imports in the compiled `dist/` folder.  
- Updated the `build` script so the fix runs right after TypeScript compilation.  
- This ensures all imports are valid for Node.js ESM without manual edits.  

---

### 3️⃣ Changes Made  
- **`package.json`**  
  - Added dependency:  
    ```json
    "tsc-esm-fix": "^3.1.2"
    ```  

  - Updated build script:  
    ```json
    "build": "tsc && tsc-esm-fix ./dist"
    ```  

---

✅ After these changes, running `npm run build && npm run seed` works correctly, and Node resolves all compiled imports without errors.  
